### PR TITLE
Deb and el7 enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Installation takes place via the instructions found
 [here](https://github.com/ayufan/gitlab-ci-multi-runner/blob/master/docs/install/linux-repository.md) - Repo is added, 
 User created and managed, and the Runners are registered.
 
-The YUM version is hard set to v0.4.2 because 0.5.0 does not run well on CentOS Systems.
+The version of the gitlab-ci-multi-runner package is restricted to `v0.4.2` for RHEL5 and RHEL6 derivatives due to
+ restrictions identified on CentOS systems. RHEL7 and Debian derivatives are set to use the most current release
+ available.
 
 ##Usage
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,26 +1,26 @@
 class gitlab_ci_multi_runner (
 ) {
-    $package_manager = $::osfamily ? {
+    $package_type = $::osfamily ? {
         'redhat'  => 'rpm',
-        'debian'  => 'apt',
+        'debian'  => 'deb',
         default => 'unknown',
     }
 
-    if $package_manager == 'unknown' {
+    if $package_type == 'unknown' {
         fail("Target Operating system (${operatingsystem}) not supported")
-    } elsif $package_manager == 'apt' {
+    } elsif $package_type == 'deb' {
         warning("${operatingsystem} support is still in Beta - please report any issues to the main repository at https://github.com/frankiethekneeman/puppet-gitlab-ci-multi-runner/issues")
     }
 
     # Get the file created by the "repo adding" step.
-    $repoLocation = $package_manager ? {
+    $repoLocation = $package_type ? {
         'rpm'   => "/etc/yum.repos.d/runner_gitlab-ci-multi-runner.repo",
-        'apt'   => "/etc/apt/sources.list.d/runner_gitlab-ci-multi-runner.list",
+        'deb'   => "/etc/deb/sources.list.d/runner_gitlab-ci-multi-runner.list",
         default => '/var',
             # Choose a file that will definitely be there so that we don't have to worry about it running in the case
             # of an unknown package_manager type.
     }
-    
+
     $version = $::osfamily ? {
         'redhat' => '0.4.2-1',
         'debian' => 'installed',
@@ -35,9 +35,9 @@ class gitlab_ci_multi_runner (
         ensure     => "present",
         managehome => "true",
     } ->
-    # Add The repository to yum/apt-get
+    # Add The repository to yum/deb-get
     exec {"Add Repository":
-        command  => "curl -L https://packages.gitlab.com/install/repositories/runner/gitlab-ci-multi-runner/script.${package_manager}.sh | bash",
+        command  => "curl -L https://packages.gitlab.com/install/repositories/runner/gitlab-ci-multi-runner/script.${package_type}.sh | bash",
         user     => root,
         provider => shell,
         creates  => $repoLocation,
@@ -57,7 +57,7 @@ class gitlab_ci_multi_runner (
         ensure => "running",
     }
 
-    if $package_manager == 'rpm' {
+    if $package_type == 'rpm' {
         exec { "Yum Exclude Line":
             command  => "echo exclude= >> /etc/yum.conf",
             onlyif   => "! grep '^exclude=' /etc/yum.conf",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "frankiethekneeman-gitlab_ci_multi_runner",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "author": "Francis J.. Van Wetering IV",
     "license": "MIT",
     "summary": "A Module to Install and register the Gitlab CI Multirunner.",
@@ -11,11 +11,15 @@
     "operatingsystem_support": [
         {
             "operatingsystem":"RedHat",
-            "operatingsystemrelease":[ "5.0", "6.0" ]
+            "operatingsystemrelease":[ "5.0", "6.0", "7.0" ]
         }
         , {
             "operatingsystem":"CentOS",
-            "operatingsystemrelease":[ "5.0", "6.0" ]
+            "operatingsystemrelease":[ "5.0", "6.0", "7.0" ]
+        }
+        , {
+            "operatingsystem":"OracleLinux",
+            "operatingsystemrelease":[ "5.0", "6.0", "7.0" ]
         }
         , {
             "operatingsystem":"Debian",


### PR DESCRIPTION
# Use 'deb' instead of 'apt' for repo script

The gitlab-ci-multi-runner repo install script for debian systems
has 'deb' in the name rather than 'apt'. Because of this change,
I went ahead and modified the var name to be package type rather
than manager, since we're differentiating between rpm and deb
packages (rather than the manager, apt).
# Add support for RHEL7 derivatives

This includes handling the move to systemd, as well as the separate
directory used by debian.

Since the fallback for CentOS to version 0.4.2-1 was for the older
version, I bumped the RHEL7 derivatives to the latest.
