### PR TITLE
Adding Niceness Control for the CI Runner Process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ The version of the gitlab-ci-multi-runner package is restricted to `v0.4.2` for 
 ##Usage
 
 ```puppet
-class {'gitlab_ci_multi_runner': }
+class {'gitlab_ci_multi_runner': 
+    nice => 15
+}
 
 gitlab_ci_multi_runner::runner { "This is My Runner":
     gitlab_ci_url => 'http://ci.gitlab.examplecorp.com'
@@ -33,6 +35,12 @@ gitlab_ci_multi_runner::runner { "This is My Second Runner":
     ssh_password  => 'password123'
 }
 ```
+
+##Installation Options
+
+#### nice
+
+control the niceness of the actual process running the CI Jobs.  Valid values are from -20 to 19.  Leading '+' is optional.
 
 ##Runner Options
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,7 +91,8 @@ class gitlab_ci_multi_runner (
         }
     }
     if $nice != undef {
-        if $nice =~ /^(-20|[-+]?[01][0-9])$/ {
+        if $nice =~ /^(-20|[-+]?1?[0-9])$/ {
+            $path = ['/bin', '/usr/bin', '/usr/sbin', '/usr/local/sbin', '/usr/local/bin', '/sbin',]
             case $serviceFile {
                 '/etc/init.d/gitlab-ci-multi-runner': {
                     $niceval = $nice ? {
@@ -99,28 +100,34 @@ class gitlab_ci_multi_runner (
                         default => "+${nice}"
                     } #The nice value passed to the daemon function must have a leading sign
                     exec {'Ensure Niceness':
-                        command  => "sed -i 's/ daemon / daemon $niceval /g' $serviceFile",
+                        command  => "sed -i 's/ daemon \\([+-][0-9]\\+ \\)\\?/ daemon $niceval /g' $serviceFile",
                         user     => root,
                         provider => shell,
-                        onlyif   => "! grep 'daemon $niceval' $serviceFile", #Only if the niceness isn't already set
+                        path     => $path,
+                        onlyif   => "! grep 'daemon $niceval ' $serviceFile", #Only if the niceness isn't already set
                         notify   => Service[$service]
                     }
                 }
                 '/etc/systemd/system/gitlab-runner.service': {
+                    $initCommand = "sed -i '/\\[Service\\]/a Nice=$nice' $serviceFile"
+                    $updateCommand = "sed -i 's/Nice=[+-]\\?[0-9]\\+/Nice=$nice/g $serviceFile"
+                    $checkCommand = "grep 'Nice=[+-]\\?[0-9]\\+' $serviceFile"
                     exec {'Ensure Niceness':
-                        command  => "sed -i '/\\[Service\\]/a Nice=$nice' $serviceFile",
+                        command  => "$checkCommand && $updateCommand || $initCommand",
                         user     => root,
                         provider => shell,
-                        onlyif   => "! grep 'Nice=$nice' $serviceFile", #Only if the niceness isn't already set
+                        path     => $path,
+                        onlyif   => "! grep 'Nice=$nice *\$' $serviceFile", #Only if the niceness isn't already set
                         notify   => Service[$service]
                     }
                 }
                 '/etc/init/gitlab-runner.conf': {
                     exec {'Ensure Niceness':
-                        command  => "sed -i 's/ start-stop-daemon / start-stop-daemon -N $niceval /g' $serviceFile",
+                        command  => "sed -i 's/ start-stop-daemon \\(-N [+-]\\?[0-9]\\+\\)\\? / start-stop-daemon -N $nice /g' $serviceFile",
                         user     => root,
                         provider => shell,
-                        onlyif   => "! grep 'start-stop-daemon -N $niceval' $serviceFile", #Only if the niceness isn't already set
+                        path     => $path,
+                        onlyif   => "! grep 'start-stop-daemon -N $nice ' $serviceFile", #Only if the niceness isn't already set
                         notify   => Service[$service]
                     }
                 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "frankiethekneeman-gitlab_ci_multi_runner",
-    "version": "0.1.7",
+    "version": "0.2.0",
     "author": "Francis J.. Van Wetering IV",
     "license": "MIT",
     "summary": "A Module to Install and register the Gitlab CI Multirunner.",


### PR DESCRIPTION
WIP Pull Request to add Niceness parameter to control niceness of CI-Runner Service.  This should allow people to run the CI runner on servers that have other more important things running, or on developer machines, without choking those other things for resources.
