### PR TITLE
Quote Runner name so it doesn't break on spaces

### DIFF
--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -132,7 +132,9 @@ define gitlab_ci_multi_runner::runner (
     $ssh_password = undef,
     $require = [ Class['gitlab_ci_multi_runner'] ],
 ) {
-    $description = $name
+    # GitLab allows runner names with problematic characters like quotes
+    # Make sure they don't trip up the shell when executed
+    $description = shellquote($name)
 
     $user = 'gitlab_ci_multi_runner'
     $group = $user


### PR DESCRIPTION
Running gitlab-ci-multi-runner-0.5.5_1_g69bc934-1  on CentOS 7 here.

Creating a Runner with a space in the name (like your examples in the README do) fails, as both the 'gitlab-ci-multi-runner register' and the 'grep' in the exec expect a single word for the description. This change simply single quotes the name when setting $description, allowing the commands to succeed both with and without spaces in the name of the runner.
