### PR TITLE
Rename description -> name

### DIFF
--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -153,7 +153,10 @@ define gitlab_ci_multi_runner::runner (
     }
 
     if $description {
-        $description_opt = "--name=${description}"
+        $description_opt = $::gitlab_ci_multi_runner::version ? {
+            /^0\.[0-4]\..*/ => "--description=${description}",
+            default         => "--name=${description}",
+        }
     }
 
     if $tags {

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -153,7 +153,7 @@ define gitlab_ci_multi_runner::runner (
     }
 
     if $description {
-        $description_opt = "--description=${description}"
+        $description_opt = "--name=${description}"
     }
 
     if $tags {


### PR DESCRIPTION
gitlab-ci-multi-runner register uses --name now not --description
