### PR TITLE
removed user param from exec command as this caused a not connected r…

### DIFF
--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -240,7 +240,6 @@ define gitlab_ci_multi_runner::runner (
     # --non-interactive means it won't ask us for things, it'll just fail out.
     exec { "Register-${name}":
         command  => "gitlab-ci-multi-runner register --non-interactive ${opts}",
-        user     => $user,
         provider => shell,
         onlyif   => "! grep ${description} ${toml_file}",
         cwd      => $home_path,


### PR DESCRIPTION
I noticed that using this module for registering new runners it ends up in the problem described here: https://codereviewvideos.com/blog/how-i-solved-new-runner-has-not-connected-yet-in-gitlab-ci/. So my runner was registered but the config went to /home/gitlab_ci_multi_runner/.gitlab-runner/confit.toml instead of /etc/gitlab-runner/confit.toml.
And the runner was not connected to GitLab. So I removed the user param from the exec command which fixes this problem.
