### PR TITLE
Check for misconfigured service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,6 +113,12 @@ class gitlab_ci_multi_runner (
     package { 'gitlab-ci-multi-runner':
         ensure => $version,
     } ->
+    exec { 'Uninstall Misconfigured Service':
+        command  => "service ${service} stop; ${service} uninstall",
+        user     => root,
+        provider => shell,
+        unless   => "grep '${toml_file}' ${serviceFile}",
+    } ->
     exec { 'Ensure Service':
         command  => "${service} install --user ${user} --config ${toml_file} --working-directory ${home_path}",
         user     => root,


### PR DESCRIPTION
Stop and uninstall runner service which is not using the correct
configuration file.

It's a first naive approach. As the `$toml_file` variable includes `$home_path` which itself includes `$user` it's probably the simplest check to perform.

Fixes #21 
