### PR TITLE
Reference to correct variable for runner check

### DIFF
--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -268,7 +268,7 @@ define gitlab_ci_multi_runner::runner (
         user     => $user,
         provider => shell,
 
-        onlyif   => "! grep ${description} ${::gitlab_ci_multi_runner::version}",
+        onlyif   => "! grep ${description} ${::gitlab_ci_multi_runner::toml_file}",
         cwd      => $home_path,
         require  => $require,
     }


### PR DESCRIPTION
Using `$version` as file to check in grep command doesn't make sense. As stated in the comment above `$toml_file` should be used.

Fixes #26 
